### PR TITLE
Update app path to include space

### DIFF
--- a/Sqwarq/DetectXSwift.pkg.recipe
+++ b/Sqwarq/DetectXSwift.pkg.recipe
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/DetectXSwift.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/DetectX Swift.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>


### PR DESCRIPTION
PKG recipe fails because app path does not include space, but the app name does have a space